### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mishurahman/ad893fcb-84d8-4245-a1c3-80343f60db12/ae40afb2-88c3-4eca-a1ca-1efb6f5743de/_apis/work/boardbadge/5c3f2a82-2e55-417f-836c-8fa6f636df67)](https://dev.azure.com/mishurahman/ad893fcb-84d8-4245-a1c3-80343f60db12/_boards/board/t/ae40afb2-88c3-4eca-a1ca-1efb6f5743de/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mishurahman/ad893fcb-84d8-4245-a1c3-80343f60db12/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.